### PR TITLE
垃圾学校又换域名，更换域名为*.tjustb.cn

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # tjustb-edusys
 
-北京科技大学天津学院教务系统客户端（https://jw.bkty.top）
+北京科技大学天津学院教务系统客户端（https://jw.tjustb.cn）
 
 # Requirement
 
@@ -44,11 +44,11 @@ print_r($score);
 
 读取环境变量，请将.env文件放在引用项目根目录下，并配置如下内容：
 
-|  变量名 | 描述         | 默认                    | 可选 |
-| --- |------------|-----------------------|----|
-| EDUSYS_OCR_URL | 验证码识别接口地址  |                       | 是  |
-| EDUSYS_URL | 访问教务系统路径   | https://jw.bkty.top | 否  |
- | EDUSYS_TIMEOUT | 请求超时时间(秒数) | 5                     | 否  |
+|  变量名 | 描述         | 默认                   | 可选 |
+| --- |------------|----------------------|----|
+| EDUSYS_OCR_URL | 验证码识别接口地址  |                      | 是  |
+| EDUSYS_URL | 访问教务系统路径   | https://jw.tjustb.cn | 否  |
+ | EDUSYS_TIMEOUT | 请求超时时间(秒数) | 5                    | 否  |
 
 ## 适用学校系统
 

--- a/src/Base.php
+++ b/src/Base.php
@@ -65,9 +65,9 @@ class Base
      * @param string $url
      * @return void
      */
-    public function setEdusysUrl(string $url = 'https://jw.bkty.top')
+    public function setEdusysUrl(string $url = 'https://jw.tjustb.cn')
     {
-        if (empty($url)) $url = 'https://jw.bkty.top';
+        if (empty($url)) $url = 'https://jw.tjustb.cn';
         $this->edusysUrl = $this->getConfig('EDUSYS_URL', $url);
     }
 
@@ -116,7 +116,7 @@ class Base
      * @param string $url 教务系统URL
      * @return void
      */
-    public function setEdusysUrlForce(string $url = 'https://jw.bkty.top')
+    public function setEdusysUrlForce(string $url = 'https://jw.tjustb.cn')
     {
         $this->edusysUrl = $url;
     }
@@ -206,7 +206,7 @@ class Base
         $origin = substr($domain[0], 0, -1);
 
         $headers = [];
-        $headers[] = 'Host: jw.bkty.top';
+        $headers[] = 'Host: jw.tjustb.cn';
         $headers[] = 'Connection: keep-alive';
         $headers[] = 'sec-ch-ua: "Not:A-Brand";v="99", "Microsoft Edge";v="145", "Chromium";v="145"';
         $headers[] = 'sec-ch-ua-mobile: ?0';
@@ -307,7 +307,7 @@ class Base
         if (strpos($html, '该帐号不存在或密码错误')) return ['code' => 403, 'data' => '用户名或密码错误'];
         if (strpos($html, '您的账号在其它地方登录')) return ['code' => 403, 'data' => '您的账号在其它地方登录'];
         if (strpos($html, '请先登录系统')) return ['code' => 403, 'data' => '未登录,请重新登录'];
-        if (strpos($html, 'authserver.bkty.top/authserver/login')) return ['code' => 403, 'data' => '未登录,请重新登录'];
+        if (strpos($html, 'authserver.tjustb.cn/authserver/login')) return ['code' => 403, 'data' => '未登录,请重新登录'];
         if (strpos($html, '非法访问')) return ['code' => 403, 'data' => '账号身份没有访问权限'];
         return true;
     }

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -177,7 +177,7 @@ class Profile extends Base
         $referer = $this->edusysUrl . '/jsxsd/grxx/xsxx';
         $response = $this->httpGet('/jsxsd/grxx/xszpLoad', $this->cookie, $referer);
         if ($response['code'] !== Base::CODE_SUCCESS) return '';
-        if (strpos($response['data'], 'authserver.bkty.top/authserver/login')) return '';
+        if (strpos($response['data'], 'authserver.tjustb.cn/authserver/login')) return '';
         return base64_encode($response['data']);
     }
 

--- a/src/SsoLogin.php
+++ b/src/SsoLogin.php
@@ -9,7 +9,7 @@ class SsoLogin extends Base
     /**
      * @var string SSO登录地址
      */
-    public string $ssoDomain = 'http://authserver.bkty.top';
+    public string $ssoDomain = 'https://authserver.tjustb.cn';
 
     /**
      * SSO登录
@@ -21,7 +21,7 @@ class SsoLogin extends Base
     {
         $url = '/jsxsd/sso.jsp?ticket=' . $ticket;
         $result = $this->httpRequest('GET', $url, '', '', [
-            'Host: jw.bkty.top',
+            'Host: jw.tjustb.cn',
             'Connection: keep-alive',
             'Upgrade-Insecure-Requests: 1',
             'Accept-Language: zh-CN,zh;q=0.9,en;q=0.8,en-GB;q=0.7,en-US;q=0.6',


### PR DESCRIPTION
更新教务系统及相关服务域名，并修复学生身份判断逻辑
1. 将全部 bkty.top 域名替换为 tjustb.cn，含README、配置及代码中的地址
2. 修复isStudent方法学号判断逻辑，T开头学号现判定为无效